### PR TITLE
Correct rosdep names in package.xml for eigne and opencv

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,8 @@
 
   <depend>libpcl-all-dev</depend>
   <depend>OpenMP</depend>
-  <depend>Eigen3</depend>
+  <depend>eigen</depend>
+  <depend>libopencv-dev</depend>
   <depend>yak</depend>
 
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
This corrects the dependencies for eigen and opencv to match the [rosdep key](https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml).