### PR TITLE
Remove depend on OpenMP

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,6 @@
 
 
   <depend>libpcl-all-dev</depend>
-  <depend>OpenMP</depend>
   <depend>eigen</depend>
   <depend>libopencv-dev</depend>
   <depend>yak</depend>


### PR DESCRIPTION
It looks like OpenMP does not have a key in rosdep, but I expect this is because it is a compiler feature not something you install through apt-get.