### PR TITLE
ROS 1 Node: Add visualization of TSDF Volume and results

### DIFF
--- a/yak_ros/CMakeLists.txt
+++ b/yak_ros/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(yak REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(visualization_msgs REQUIRED)
 #find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_eigen REQUIRED)
@@ -48,11 +49,20 @@ if ($ENV{ROS_VERSION} VERSION_EQUAL "1")
          geometry_msgs
          sensor_msgs
          std_msgs
+         visualization_msgs
          yak_ros_msgs
        DEPENDS
          yak
          tf2_eigen
          tf2)
+
+     add_library(${PROJECT_NAME}_visualizer_ros1 src/yak_ros1/visualizer_ros1.cpp)
+     add_dependencies(${PROJECT_NAME}_visualizer_ros1 ${catkin_EXPORTED_TARGETS})
+     target_link_libraries(${PROJECT_NAME}_visualizer_ros1 ${catkin_LIBRARIES})
+     target_include_directories(${PROJECT_NAME}_visualizer_ros1 PUBLIC
+         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+         "$<INSTALL_INTERFACE:include>")
+     target_include_directories(${PROJECT_NAME}_visualizer_ros1 PUBLIC ${catkin_INCLUDE_DIRS})
 
      add_executable(${PROJECT_NAME}_node
          src/yak_ros1_node.cpp)
@@ -66,7 +76,8 @@ if ($ENV{ROS_VERSION} VERSION_EQUAL "1")
          ${cv_bridge_LIBRARIES}
          yak::yak
          yak::yak_frontend
-         yak::yak_marching_cubes)
+         yak::yak_marching_cubes
+         ${PROJECT_NAME}_visualizer_ros1)
      target_include_directories(${PROJECT_NAME}_node PUBLIC
          "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
          "$<INSTALL_INTERFACE:include>")

--- a/yak_ros/include/yak_ros/online_fusion_server_ros1.h
+++ b/yak_ros/include/yak_ros/online_fusion_server_ros1.h
@@ -38,6 +38,8 @@
 #include <yak_ros_msgs/GenerateMesh.h>
 #include <yak_ros_msgs/UpdateKinFuParams.h>
 
+#include <queue>
+
 namespace yak_ros
 {
 /**
@@ -116,6 +118,9 @@ private:
   Eigen::Affine3d tsdf_frame_to_camera_prev_;
   /** @brief TF frame associated with the TSDF volume. */
   std::string tsdf_frame_;
+  /** @brief Queue that stores images until their transforms are available. This allows for the mismatch in timing
+   * between images being published and TFs */
+  std::queue<sensor_msgs::ImageConstPtr> image_queue_;
 };
 }  // namespace yak_ros
 

--- a/yak_ros/include/yak_ros/online_fusion_server_ros1.h
+++ b/yak_ros/include/yak_ros/online_fusion_server_ros1.h
@@ -37,6 +37,7 @@
 #include <sensor_msgs/Image.h>
 #include <yak_ros_msgs/GenerateMesh.h>
 #include <yak_ros_msgs/UpdateKinFuParams.h>
+#include <yak_ros/visualizer_ros1.h>
 
 #include <queue>
 
@@ -121,6 +122,8 @@ private:
   /** @brief Queue that stores images until their transforms are available. This allows for the mismatch in timing
    * between images being published and TFs */
   std::queue<sensor_msgs::ImageConstPtr> image_queue_;
+  /** @brief Used to visualize results in rviz */
+  VisualizerRos1 visualizer_;
 };
 }  // namespace yak_ros
 

--- a/yak_ros/include/yak_ros/visualizer_ros1.h
+++ b/yak_ros/include/yak_ros/visualizer_ros1.h
@@ -1,0 +1,130 @@
+/**
+ * @file visualizer_ros1.j
+ * @brief Publishes visualization messages for RVIZ
+ *
+ * @author Matthew Powelson
+ * @date December 2, 2019
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2019, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef YAK_ROS_VISUALIZER_ROS1_H
+#define YAK_ROS_VISUALIZER_ROS1_H
+
+#include <ros/ros.h>
+#include <ros/timer.h>
+
+namespace yak_ros
+{
+/**
+ * @brief Structure for containing the information to define a bounding box
+ */
+struct BoundingBox
+{
+  BoundingBox() : neg_x_(0), neg_y_(0), neg_z_(0), pos_x_(1), pos_y_(1), pos_z_(1), frame_("tsdf_frame") {}
+  BoundingBox(double& neg_x,
+              double& neg_y,
+              double& neg_z,
+              double& pos_x,
+              double& pos_y,
+              double& pos_z,
+              std::string& frame)
+    : neg_x_(neg_x), neg_y_(neg_y), neg_z_(neg_z), pos_x_(pos_x), pos_y_(pos_y), pos_z_(pos_z), frame_(frame)
+  {
+  }
+  /** @brief Location of yz plane in negative direction */
+  double neg_x_;
+  /** @brief Location of xz plane in negative direction */
+  double neg_y_;
+  /** @brief Location of xy plane in negative direction */
+  double neg_z_;
+  /** @brief Location of yz plane in positive direction */
+  double pos_x_;
+  /** @brief Location of xz plane in positive direction */
+  double pos_y_;
+  /** @brief Location of xy plane in positive direction */
+  double pos_z_;
+  /** @brief Frame to which these dimensions are relative */
+  std::string frame_;
+};
+
+/**
+ * @brief This class visualizes useful information for yak_ros1_node. It publishes the tsdf volume as a bounding box as
+ * well as the resultant mesh.
+ *
+ * Note that these markers are published every second by a ROS timer that is started when the feature is set and stopped
+ * when the feature is cleared.
+ */
+class VisualizerRos1
+{
+public:
+  /**
+   * @brief Constructor
+   * @param nh Nodehandle associated with the marker publisher
+   * @param frame_id The TF frame associated with tsdf volume.
+   */
+  VisualizerRos1(const ros::NodeHandle& nh, const std::string& frame_id);
+
+  /**
+   * @brief setBoundingBox Sets the size of the bounding box and resets the publisher
+   * @param neg_x Location of yz plane in negative direction
+   * @param neg_y Location of xz plane in negative direction
+   * @param neg_z Location of xy plane in negative direction
+   * @param pos_x Location of yz plane in positive direction
+   * @param pos_y Location of xz plane in positive direction
+   * @param pos_z Location of xy plane in positive direction
+   */
+  void setBoundingBox(const double& neg_x,
+                      const double& neg_y,
+                      const double& neg_z,
+                      const double& pos_x,
+                      const double& pos_y,
+                      const double& pos_z);
+  /** @brief Clears the bounding box marker and stops the bounding box timer */
+  void clearBoundingBox();
+  /**
+   * @brief Sets the mesh resource associated with the mesh marker and starts the mesh marker timer
+   * @param mesh_resource The mesh resource for the mesh marker
+   */
+  void setMeshResource(const std::string& mesh_resource);
+  /** @brief Clears the mesh marker and stops mesh marker timer */
+  void clearMesh();
+  /** @brief Frame with which the markers are associated */
+  std::string frame_id_;
+
+private:
+  /** @brief ROS timer callback to publish the bounding box */
+  void publishBoundingBoxCallback(const ros::TimerEvent&);
+  /** @brief ROS timer callback to publish the mesh */
+  void publishMeshCallback(const ros::TimerEvent&);
+  /** @brief Bounding box defining the TSDF Volume */
+  BoundingBox bbox_;
+  /** @brief Mesh resource defining the TSDF results */
+  std::string mesh_resource_;
+  /** @brief Timer used to publish the bounding box at regular intervals (1 second) */
+  ros::Timer bbox_timer_;
+  /** @brief Timer used to publish the mesh at regular intervals (1 second) */
+  ros::Timer mesh_timer_;
+  /** @brief Nodehandle associated with the marker publisher */
+  ros::NodeHandle nh_;
+  /** @brief Publisher for markers */
+  ros::Publisher vis_publisher_;
+};
+}  // namespace yak_ros
+
+#endif

--- a/yak_ros/package.xml
+++ b/yak_ros/package.xml
@@ -25,6 +25,7 @@
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>visualization_msgs</depend>
 
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/yak_ros/src/yak_ros1/visualizer_ros1.cpp
+++ b/yak_ros/src/yak_ros1/visualizer_ros1.cpp
@@ -1,0 +1,168 @@
+#include <yak_ros/visualizer_ros1.h>
+#include <visualization_msgs/Marker.h>
+#include <functional>
+
+using namespace yak_ros;
+
+/**
+ * @brief Makes a geometry_msgs::Point from the 3 values
+ * @param x x value in output point
+ * @param y y value in output point
+ * @param z z value in output point
+ * @return Returnts a geometry_msgs::Point constructed from the xyz values passed in
+ */
+static inline geometry_msgs::Point MakePoint(const double& x, const double& y, const double& z)
+{
+  geometry_msgs::Point pnt;
+  pnt.x = x;
+  pnt.y = y;
+  pnt.z = z;
+  return pnt;
+}
+
+VisualizerRos1::VisualizerRos1(const ros::NodeHandle& nh, const std::string& frame_id) : frame_id_(frame_id), nh_(nh)
+{
+  vis_publisher_ = nh_.advertise<visualization_msgs::Marker>("visualization_marker", 0);
+  mesh_timer_ =
+      nh_.createTimer(ros::Duration(1), std::bind(&VisualizerRos1::publishMeshCallback, this, std::placeholders::_1));
+  bbox_timer_ = nh_.createTimer(ros::Duration(1),
+                                std::bind(&VisualizerRos1::publishBoundingBoxCallback, this, std::placeholders::_1));
+  clearMesh();
+  clearBoundingBox();
+}
+
+void VisualizerRos1::setBoundingBox(const double& neg_x,
+                                    const double& neg_y,
+                                    const double& neg_z,
+                                    const double& pos_x,
+                                    const double& pos_y,
+                                    const double& pos_z)
+{
+  bbox_.neg_x_ = neg_x;
+  bbox_.neg_y_ = neg_y;
+  bbox_.neg_z_ = neg_z;
+  bbox_.pos_x_ = pos_x;
+  bbox_.pos_y_ = pos_y;
+  bbox_.pos_z_ = pos_z;
+  bbox_.frame_ = frame_id_;
+
+  bbox_timer_.start();
+}
+
+void VisualizerRos1::clearBoundingBox()
+{
+  bbox_timer_.stop();
+  // Send delete
+  visualization_msgs::Marker marker;
+  marker.header.frame_id = frame_id_;
+  marker.header.stamp = ros::Time::now();
+  marker.ns = "yak_ros";
+  marker.id = 1;
+  marker.type = visualization_msgs::Marker::LINE_LIST;
+  marker.action = visualization_msgs::Marker::DELETE;
+
+  vis_publisher_.publish(marker);
+}
+
+void VisualizerRos1::setMeshResource(const std::string& mesh_resource)
+{
+  mesh_resource_ = "file://" + mesh_resource;
+  mesh_timer_.start();
+}
+
+void VisualizerRos1::clearMesh()
+{
+  mesh_timer_.stop();
+  // Send delete
+  visualization_msgs::Marker marker;
+  marker.header.frame_id = frame_id_;
+  marker.header.stamp = ros::Time::now();
+  marker.ns = "yak_ros";
+  marker.id = 0;
+  marker.type = visualization_msgs::Marker::MESH_RESOURCE;
+  marker.action = visualization_msgs::Marker::DELETE;
+
+  vis_publisher_.publish(marker);
+}
+
+void VisualizerRos1::publishBoundingBoxCallback(const ros::TimerEvent&)
+{
+  visualization_msgs::Marker marker;
+  marker.header.frame_id = frame_id_;
+  marker.header.stamp = ros::Time::now();
+  marker.ns = "yak_ros";
+  marker.id = 1;
+  marker.scale.x = 0.005;  // Line width
+  marker.pose.orientation.w = 1.0;
+  marker.color.r = 1.0;
+  marker.color.g = 0.0;
+  marker.color.b = 0.0;
+  marker.color.a = 1.0;
+  marker.type = visualization_msgs::Marker::LINE_LIST;
+  marker.action = visualization_msgs::Marker::ADD;
+  //  marker.frame_locked = true;  // Should be enabled if the frame is moving
+
+  // X Direction
+  marker.points.push_back(MakePoint(bbox_.neg_x_, bbox_.neg_y_, bbox_.neg_z_));
+  marker.points.push_back(MakePoint(bbox_.pos_x_, bbox_.neg_y_, bbox_.neg_z_));
+
+  marker.points.push_back(MakePoint(bbox_.neg_x_, bbox_.pos_y_, bbox_.neg_z_));
+  marker.points.push_back(MakePoint(bbox_.pos_x_, bbox_.pos_y_, bbox_.neg_z_));
+
+  marker.points.push_back(MakePoint(bbox_.neg_x_, bbox_.neg_y_, bbox_.pos_z_));
+  marker.points.push_back(MakePoint(bbox_.pos_x_, bbox_.neg_y_, bbox_.pos_z_));
+
+  marker.points.push_back(MakePoint(bbox_.neg_x_, bbox_.pos_y_, bbox_.pos_z_));
+  marker.points.push_back(MakePoint(bbox_.pos_x_, bbox_.pos_y_, bbox_.pos_z_));
+
+  // Y Direction
+  marker.points.push_back(MakePoint(bbox_.neg_x_, bbox_.neg_y_, bbox_.neg_z_));
+  marker.points.push_back(MakePoint(bbox_.neg_x_, bbox_.pos_y_, bbox_.neg_z_));
+
+  marker.points.push_back(MakePoint(bbox_.pos_x_, bbox_.neg_y_, bbox_.neg_z_));
+  marker.points.push_back(MakePoint(bbox_.pos_x_, bbox_.pos_y_, bbox_.neg_z_));
+
+  marker.points.push_back(MakePoint(bbox_.neg_x_, bbox_.neg_y_, bbox_.pos_z_));
+  marker.points.push_back(MakePoint(bbox_.neg_x_, bbox_.pos_y_, bbox_.pos_z_));
+
+  marker.points.push_back(MakePoint(bbox_.pos_x_, bbox_.neg_y_, bbox_.pos_z_));
+  marker.points.push_back(MakePoint(bbox_.pos_x_, bbox_.pos_y_, bbox_.pos_z_));
+
+  // Z Direction
+  marker.points.push_back(MakePoint(bbox_.neg_x_, bbox_.neg_y_, bbox_.neg_z_));
+  marker.points.push_back(MakePoint(bbox_.neg_x_, bbox_.neg_y_, bbox_.pos_z_));
+
+  marker.points.push_back(MakePoint(bbox_.pos_x_, bbox_.neg_y_, bbox_.neg_z_));
+  marker.points.push_back(MakePoint(bbox_.pos_x_, bbox_.neg_y_, bbox_.pos_z_));
+
+  marker.points.push_back(MakePoint(bbox_.neg_x_, bbox_.pos_y_, bbox_.neg_z_));
+  marker.points.push_back(MakePoint(bbox_.neg_x_, bbox_.pos_y_, bbox_.pos_z_));
+
+  marker.points.push_back(MakePoint(bbox_.pos_x_, bbox_.pos_y_, bbox_.neg_z_));
+  marker.points.push_back(MakePoint(bbox_.pos_x_, bbox_.pos_y_, bbox_.pos_z_));
+
+  vis_publisher_.publish(marker);
+}
+
+void VisualizerRos1::publishMeshCallback(const ros::TimerEvent&)
+{
+  visualization_msgs::Marker marker;
+  marker.header.frame_id = frame_id_;
+  marker.header.stamp = ros::Time::now();
+  marker.ns = "yak_ros";
+  marker.id = 0;
+  marker.scale.x = 1.0;
+  marker.scale.y = 1.0;
+  marker.scale.z = 1.0;
+  marker.pose.orientation.w = 1.0;
+  marker.color.r = 0.0;
+  marker.color.g = 1.0;
+  marker.color.b = 0.0;
+  marker.color.a = 1.0;
+  marker.type = visualization_msgs::Marker::MESH_RESOURCE;
+  marker.action = visualization_msgs::Marker::ADD;
+  //  marker.frame_locked = true;  // Should be enabled if the frame is moving
+
+  marker.mesh_resource = mesh_resource_;
+  vis_publisher_.publish(marker);
+}


### PR DESCRIPTION
Adds a visualizer that publishes the TSDF volume as a bounding box. The results mesh is published when generateMesh is called and is cleared when reset is called. Each of the markers is published on a timer at 1 second intervals. 

Here is an example visualization.
![Screenshot from 2019-12-02 14-54-54](https://user-images.githubusercontent.com/12128406/69996278-543df880-1517-11ea-829c-c9a23d7bebf4.png)
