### PR TITLE
Fix misplaced volume size params in demo launch file

### DIFF
--- a/yak_ros/launch/demo.launch
+++ b/yak_ros/launch/demo.launch
@@ -1,11 +1,6 @@
 <launch>
   <node name="image_sim_node" pkg="yak_ros" type="yak_ros_image_simulator">
     <param name="base_frame" value="world"/>
-
-    <param name="volume_x" value="640"/>
-    <param name="volume_y" value="640"/>
-    <param name="volume_z" value="320"/>
-
     <param name="mesh" value="$(find yak_ros)/demo/bun_on_table.ply"/>
     <param name="orbit_speed" value="1.0"/>
     <param name="framerate" value="30"/>
@@ -19,7 +14,12 @@
     <rosparam param="camera_matrix">[550.0, 0.0, 320.0, 0.0, 550.0, 240.0, 0.0, 0.0, 1.0]</rosparam>
     <param name="cols" value="640"/>
     <param name="rows" value="480"/>
+
+    <param name="volume_resolution" value="0.001"/>
+    <param name="volume_x" value="640"/>
+    <param name="volume_y" value="640"/>
+    <param name="volume_z" value="192"/>
   </node>
 
-  <node pkg="tf" type="static_transform_publisher" name="link1_broadcaster" args="-0.3 -0.3 0 0 0 0 1 world tsdf_origin 100" />
+  <node pkg="tf" type="static_transform_publisher" name="link1_broadcaster" args="-0.3 -0.3 -0.01 0 0 0 1 world tsdf_origin 100" />
 </launch>

--- a/yak_ros/src/yak_ros1_node.cpp
+++ b/yak_ros/src/yak_ros1_node.cpp
@@ -250,6 +250,7 @@ int main(int argc, char** argv)
   pnh.param<float>("volume_resolution", kinfu_params.volume_resolution, 0.002f);
   kinfu_params.volume_dims = cv::Vec3i(volume_x, volume_y, volume_z);
   ROS_INFO_STREAM("TSDF Volume Dimensions (Voxels): " << kinfu_params.volume_dims);
+  ROS_INFO_STREAM("TSDF Volume Resolution (m): " << kinfu_params.volume_resolution);
 
   // This is not settable via ROS. Change by moving TSDF frame in TF
   kinfu_params.volume_pose = Eigen::Affine3f::Identity();


### PR DESCRIPTION
- Move the `volume_x`, etc. params to the correct node in demo.launch.
- Change volume size and resolution to be more suitable to the demo mesh.
- Translate the origin of the TSDF volume slightly downward to make sure the surface of the simulated table is some distance into the volume.
- Add an info log message to display the specified volume resolution when starting the yak_ros node.