### PR TITLE
Add dependencies.rosinstall and better installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,48 @@
 # yak_ros
 
-Example ROS frontend node for [the Yak TSDF package](https://github.com/ros-industrial/yak).
+This is an example ROS frontend node for [the Yak TSDF package](https://github.com/ros-industrial/yak). This package depends on Yak, so follow the Yak installation instructions to make sure its prerequisites are satisfied before building `yak_ros`.
+
+## Installation
+
+### ROS Melodic
+
+These instructions assume that you have a ROS1 Catkin workspace at `~/catkin_ws`. Modify as needed to match your environment.
+
+Download dependendencies that need to be built from source:
+
+```
+cd ~/catkin_ws/src
+git clone https://github.com/ros-industrial/yak_ros.git
+wstool init .
+wstool merge -t . yak_ros/dependencies.rosinstall
+wstool update -t .
+```
+
+Use Catkin to build the workspace:
+
+```
+cd ~/catkin_ws
+catkin build
+source devel/setup.bash
+```
+
+### ROS2 (Dashing and newer)
+
+(WIP)
 
 ## Demo
 
 This package contains a simulated image generator node and a launch file to provide a self-contained demonstration of TSDF reconstruction from streaming depth images. Currently the demo is only supported for ROS1.
 
-The demo depends on [the gl_depth_sim package](https://github.com/Jmeyer1292/gl_depth_sim) to provide simulated depth images.
+The demo depends on [the gl_depth_sim package](https://github.com/Jmeyer1292/gl_depth_sim) to provide simulated depth images. Dependencies for the demo are listed separately in `demo_dependencies.rosinstall`.
 
-The demo node depends on external packages that aren't required by the core `yak_ros` node, so compilationo of the demo node is skipped by default. To build the demo, pass the `BUILD_DEMO` flag to catkin as `True`:
+```
+cd ~/catkin_ws/src
+wstool merge -t . yak_ros/demo_dependencies.rosinstall
+wstool update -t .
+```
+
+The demo node depends on external packages that aren't required by the core `yak_ros` node, so compilation of the demo node is skipped by default. To build the demo, pass the `BUILD_DEMO` flag to catkin as `True`:
 
 ```
 catkin build --cmake-args -DBUILD_DEMO=True

--- a/demo_dependencies.rosinstall
+++ b/demo_dependencies.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: gl_depth_sim
+    uri: https://github.com/Jmeyer1292/gl_depth_sim.git
+    version: master

--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    local-name: yak
+    uri: https://github.com/ros-industrial/yak.git
+    version: devel


### PR DESCRIPTION
Should help fix problems like #19.

- Add `dependencies.rosinstall` and `demo_dependencies.rosinstall`.
- Expand and clarify installation instructions.