### PR TITLE
Get camera intrinsics from camera_info topic

### DIFF
--- a/yak_ros/launch/demo.launch
+++ b/yak_ros/launch/demo.launch
@@ -8,12 +8,10 @@
 
 
   <node name="tsdf_node" pkg="yak_ros" type="yak_ros_node">
-    <remap from="~input_depth_image" to="/image"/>
+    <remap from="~input_depth_image/image" to="/sim_depth_camera/image"/>
+    <remap from="~input_depth_image/camera_info" to="/sim_depth_camera/camera_info"/>
 
     <param name="tsdf_frame" value="tsdf_origin"/>
-    <rosparam param="camera_matrix">[550.0, 0.0, 320.0, 0.0, 550.0, 240.0, 0.0, 0.0, 1.0]</rosparam>
-    <param name="cols" value="640"/>
-    <param name="rows" value="480"/>
 
     <param name="volume_resolution" value="0.001"/>
     <param name="volume_x" value="640"/>

--- a/yak_ros/src/yak_ros1_node.cpp
+++ b/yak_ros/src/yak_ros1_node.cpp
@@ -9,6 +9,7 @@
 #include <pcl/common/transforms.h>
 
 #include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/CameraInfo.h>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <cv_bridge/cv_bridge.h>
@@ -22,6 +23,7 @@
 using namespace yak_ros;
 
 static const std::double_t DEFAULT_MINIMUM_TRANSLATION = 0.00001;
+static const std::string DEFAULT_DEPTH_IMAGE_TOPIC = "input_depth_image";
 
 OnlineFusionServer::OnlineFusionServer(ros::NodeHandle& nh,
                                        const kfusion::KinFuParams& params,
@@ -35,7 +37,7 @@ OnlineFusionServer::OnlineFusionServer(ros::NodeHandle& nh,
 {
   // Subscribe to depth images published on the topic named by the depth_topic param. Set up callback to integrate
   // images when received.
-  depth_image_raw_sub_ = nh.subscribe("input_depth_image", 1, &OnlineFusionServer::onReceivedDepthImg, this);
+  depth_image_raw_sub_ = nh.subscribe(DEFAULT_DEPTH_IMAGE_TOPIC + "/image", 1, &OnlineFusionServer::onReceivedDepthImg, this);
 
   // Subscribe to point cloud
   point_cloud_sub_ = nh.subscribe("input_point_cloud", 1, &OnlineFusionServer::onReceivedPointCloud, this);
@@ -281,18 +283,38 @@ int main(int argc, char** argv)
 
   kfusion::KinFuParams kinfu_params = kfusion::KinFuParams::default_params();
 
-  // Size of the input image
-  pnh.param<int>("cols", kinfu_params.cols, 640);
-  pnh.param<int>("rows", kinfu_params.rows, 480);
 
-  // Get camera intrinsics from params
-  XmlRpc::XmlRpcValue camera_matrix;
-  pnh.getParam("camera_matrix", camera_matrix);
-  kinfu_params.intr.fx = static_cast<float>(static_cast<double>(camera_matrix[0]));
-  kinfu_params.intr.fy = static_cast<float>(static_cast<double>(camera_matrix[4]));
-  kinfu_params.intr.cx = static_cast<float>(static_cast<double>(camera_matrix[2]));
-  kinfu_params.intr.cy = static_cast<float>(static_cast<double>(camera_matrix[5]));
-  ROS_INFO("Camera Intr Params: %f %f %f %f\n",
+
+  std::string camera_info_topic = pnh.getNamespace() + "/" + DEFAULT_DEPTH_IMAGE_TOPIC + "/camera_info";
+  ROS_DEBUG("Looking for CameraInfo msgs on topic %s", camera_info_topic.c_str());
+  auto camera_info = ros::topic::waitForMessage<sensor_msgs::CameraInfo>(camera_info_topic, ros::Duration(5.0));
+  if (camera_info == nullptr)
+  {
+      ROS_WARN("Failed to find camera info topic. Loading intrinsics from parameters instead.");
+      // Get camera intrinsics from params
+      XmlRpc::XmlRpcValue camera_matrix;
+      pnh.getParam("camera_matrix", camera_matrix);
+      kinfu_params.intr.fx = static_cast<float>(static_cast<double>(camera_matrix[0]));
+      kinfu_params.intr.fy = static_cast<float>(static_cast<double>(camera_matrix[4]));
+      kinfu_params.intr.cx = static_cast<float>(static_cast<double>(camera_matrix[2]));
+      kinfu_params.intr.cy = static_cast<float>(static_cast<double>(camera_matrix[5]));
+
+      pnh.param<int>("cols", kinfu_params.cols, 640);
+      pnh.param<int>("rows", kinfu_params.rows, 480);
+  }
+  else
+  {
+      ROS_DEBUG("Found CameraInfo msg");
+      kinfu_params.intr.fx = static_cast<float>(camera_info->K[0]);
+      kinfu_params.intr.fy = static_cast<float>(camera_info->K[4]);
+      kinfu_params.intr.cx = static_cast<float>(camera_info->K[2]);
+      kinfu_params.intr.cy = static_cast<float>(camera_info->K[5]);
+
+      kinfu_params.cols = static_cast<int>(camera_info->width);
+      kinfu_params.rows = static_cast<int>(camera_info->height);
+  }
+
+  ROS_INFO("Camera Intrinsic Params: %f %f %f %f\n",
            static_cast<double>(kinfu_params.intr.fx),
            static_cast<double>(kinfu_params.intr.fy),
            static_cast<double>(kinfu_params.intr.cx),

--- a/yak_ros/src/yak_ros1_node.cpp
+++ b/yak_ros/src/yak_ros1_node.cpp
@@ -287,7 +287,7 @@ int main(int argc, char** argv)
 
   std::string camera_info_topic = pnh.getNamespace() + "/" + DEFAULT_DEPTH_IMAGE_TOPIC + "/camera_info";
   ROS_DEBUG("Looking for CameraInfo msgs on topic %s", camera_info_topic.c_str());
-  auto camera_info = ros::topic::waitForMessage<sensor_msgs::CameraInfo>(camera_info_topic, ros::Duration(5.0));
+  auto camera_info = ros::topic::waitForMessage<sensor_msgs::CameraInfo>(camera_info_topic, ros::Duration(1.0));
   if (camera_info == nullptr)
   {
       ROS_WARN("Failed to find camera info topic. Loading intrinsics from parameters instead.");


### PR DESCRIPTION
Implements #25 (@gavanderhoorn)

- Use `ros::topic::waitForMessage` when initializing the yak_ros node to get camera intrinsics published on the `camera_info` topic for the subscribed depth camera. If no topic is found, fall back to loading from ROS parameters instead.
- Change the simulated depth image publisher to use the `image_transport::CameraPublisher`, which publishes a `camera_info` topic. The default depth image topic is now `sim_depth_camera/image`, and camera info is published on `sim_depth_camera/camera_info`.
- Change `demo.launch` to use this new functionality. In particular note that the topic remaps have changed.