### PR TITLE
Remove clipped points instead of shifting them

### DIFF
--- a/yak_ros/src/yak_ros1_node.cpp
+++ b/yak_ros/src/yak_ros1_node.cpp
@@ -92,7 +92,7 @@ void OnlineFusionServer::onReceivedPointCloud(const sensor_msgs::PointCloud2Cons
       int pixel_pos_x = (int)(u + centre_x);
       int pixel_pos_y = (int)(v + centre_y);
 
-      if (pixel_pos_x > (image_width - 1) || pixel_pos_y > (image_height - 1))
+      if (pixel_pos_x < 0 || pixel_pos_y < 0 || pixel_pos_x > (image_width - 1) || pixel_pos_y > (image_height - 1))
       {
         continue;
       }

--- a/yak_ros/src/yak_ros1_node.cpp
+++ b/yak_ros/src/yak_ros1_node.cpp
@@ -92,13 +92,9 @@ void OnlineFusionServer::onReceivedPointCloud(const sensor_msgs::PointCloud2Cons
       int pixel_pos_x = (int)(u + centre_x);
       int pixel_pos_y = (int)(v + centre_y);
 
-      if (pixel_pos_x > (image_width - 1))
+      if (pixel_pos_x > (image_width - 1) || pixel_pos_y > (image_height - 1))
       {
-        pixel_pos_x = image_width - 1;
-      }
-      if (pixel_pos_y > (image_height - 1))
-      {
-        pixel_pos_y = image_height - 1;
+        continue;
       }
       cv_image.at<float>(pixel_pos_y, pixel_pos_x) = z;
     }


### PR DESCRIPTION
Instead of shifting the points outside the visible area to the borders, shouldn't we ignore those points and continue in the loop? Also, is it possible that `pixel_pos_x` and `pixel_pos_y` get negative values (e.g. wrong camera matrix)? If so, maybe catching this error and notifying the user is useful.

I'm sorry if I just misunderstood the code.