### PR TITLE
Fix typo of ROS_WARN_STREAM macro name

### DIFF
--- a/yak_ros/src/yak_ros1_node.cpp
+++ b/yak_ros/src/yak_ros1_node.cpp
@@ -105,7 +105,7 @@ void OnlineFusionServer::onReceivedPointCloud(const sensor_msgs::PointCloud2Cons
   if (pixel_outside_bounds != 0)
   {
       // Print warning if projected point is outside of image bounds
-      ROS_WARNING_STREAM("Discarded " << pixel_outside_bounds << " points because they were out of bounds. "
+      ROS_WARN_STREAM("Discarded " << pixel_outside_bounds << " points because they were out of bounds. "
                         << "Your camera matrix might be set incorrectly.");
   }
 


### PR DESCRIPTION
Fix the typo `ROS_WARNING_STREAM > ROS_WARN_STREAM` introduced in 895966c8db7fc80f11c82b9cd3530fec6dfc562b. 