### PR TITLE
Add Github Actions for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 4 * * *'
+
+jobs:
+  industrial_ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - {OS_NAME: ubuntu,
+             OS_CODE_NAME: bionic,
+             ROS_DISTRO: melodic,
+             ROSDEP_SKIP_KEYS: nvidia-cuda-dev,
+             BADGE: bionic,
+             UPSTREAM_CMAKE_ARGS: "-DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs/",
+             UPSTREAM_WORKSPACE: 'github:ros-industrial/yak#devel github:Jmeyer1292/gl_depth_sim#master',
+             TARGET_CMAKE_ARGS: "-DBUILD_DEMO=True",
+             DOCKER_PULL: false,
+             DOCKER_IMAGE: "schornakj/yak_ci:bionic-cuda10.2"}
+          - {OS_NAME: ubuntu,
+             OS_CODE_NAME: bionic,
+             ROS_DISTRO: melodic,
+             ROSDEP_SKIP_KEYS: nvidia-cuda-dev,
+             BADGE: bionic,
+             UPSTREAM_CMAKE_ARGS: "-DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs/",
+             UPSTREAM_WORKSPACE: 'github:ros-industrial/yak#devel github:Jmeyer1292/gl_depth_sim#master',
+             TARGET_CMAKE_ARGS: "-DBUILD_DEMO=True",
+             DOCKER_PULL: false,
+             DOCKER_IMAGE: "schornakj/yak_ci:bionic-cuda9.2"}
+          - {OS_NAME: ubuntu,
+             OS_CODE_NAME: xenial,
+             ROS_DISTRO: kinetic,
+             ROSDEP_SKIP_KEYS: nvidia-cuda-dev libpcl-all-dev pcl_ros,
+             BADGE: xenial,
+             ADDITIONAL_DEBS: ros-kinetic-opencv3,
+             UPSTREAM_CMAKE_ARGS: "-DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs/",
+             UPSTREAM_WORKSPACE: 'github:ros-industrial/yak#devel github:ros-perception/perception_pcl#kinetic-devel github:Jmeyer1292/gl_depth_sim#master',
+             TARGET_CMAKE_ARGS: "-DBUILD_DEMO=True",
+             DOCKER_PULL: false,
+             DOCKER_IMAGE: "schornakj/yak-1:xenial-cuda10.2"}
+          - {OS_NAME: ubuntu,
+             OS_CODE_NAME: xenial,
+             ROS_DISTRO: kinetic,
+             ROSDEP_SKIP_KEYS: nvidia-cuda-dev libpcl-all-dev pcl_ros,
+             BADGE: xenial,
+             ADDITIONAL_DEBS: ros-kinetic-opencv3,
+             UPSTREAM_CMAKE_ARGS: "-DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs/",
+             UPSTREAM_WORKSPACE: 'github:ros-industrial/yak#devel github:ros-perception/perception_pcl#kinetic-devel github:Jmeyer1292/gl_depth_sim#master',
+             TARGET_CMAKE_ARGS: "-DBUILD_DEMO=True",
+             DOCKER_PULL: false,
+             DOCKER_IMAGE: "schornakj/yak-1:xenial-cuda9.2"}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{matrix.env}}

--- a/yak_ros/CMakeLists.txt
+++ b/yak_ros/CMakeLists.txt
@@ -21,13 +21,13 @@ find_package(tf2_eigen REQUIRED)
 find_package(cv_bridge REQUIRED)
 
 find_package(Eigen3 REQUIRED)
-find_package(OpenCV REQUIRED COMPONENTS core highgui)
 
 if ($ENV{ROS_VERSION} VERSION_EQUAL "1")
     # Build as a Catkin package for ROS
 
     find_package(catkin REQUIRED COMPONENTS
          roscpp
+         pcl_ros
          tf2
          tf2_ros
          tf2_eigen
@@ -37,7 +37,6 @@ if ($ENV{ROS_VERSION} VERSION_EQUAL "1")
      catkin_package(
        INCLUDE_DIRS
        LIBRARIES
-         ${OpenCV_LIBS}
          ${yak_LIBRARIES}
          ${sensor_msgs_LIBRARIES}
          ${tf2_LIBRARIES}
@@ -47,6 +46,7 @@ if ($ENV{ROS_VERSION} VERSION_EQUAL "1")
        CATKIN_DEPENDS
          cv_bridge
          geometry_msgs
+         pcl_ros
          sensor_msgs
          std_msgs
          visualization_msgs
@@ -68,7 +68,6 @@ if ($ENV{ROS_VERSION} VERSION_EQUAL "1")
          src/yak_ros1_node.cpp)
      target_link_libraries(${PROJECT_NAME}_node
          ${CATKIN_LIBRARIES}
-         ${OpenCV_LIBS}
          ${sensor_msgs_LIBRARIES}
          ${tf2_LIBRARIES}
          ${tf2_ros_LIBRARIES}
@@ -94,7 +93,6 @@ if ($ENV{ROS_VERSION} VERSION_EQUAL "1")
           src/demo/sim_depth_image_pub_ros1.cpp)
         target_link_libraries(${PROJECT_NAME}_image_simulator
           ${CATKIN_LIBRARIES}
-          ${OpenCV_LIBS}
           ${sensor_msgs_LIBRARIES}
           ${cv_bridge_LIBRARIES}
           ${gl_depth_sim_LIBRARIES}
@@ -122,7 +120,6 @@ else()
 
     target_link_libraries(${PROJECT_NAME}_node
         ${rclcpp_LIBRARIES}
-        ${OpenCV_LIBS}
         yak::yak
         yak::yak_frontend
         yak::yak_marching_cubes
@@ -161,7 +158,7 @@ endif()
 install(TARGETS ${PROJECT_NAME}_node
         RUNTIME DESTINATION ${ROS_LIB_DESTINATION})
 
-install(DIRECTORY launch config demo
+install(DIRECTORY launch demo
         DESTINATION ${ROS_SHARE_DESTINATION})
 
 if (DEFINED BUILD_DEMO)

--- a/yak_ros/package.xml
+++ b/yak_ros/package.xml
@@ -17,7 +17,6 @@
 
   <depend>libpcl-all-dev</depend>
   <depend>eigen</depend>
-  <depend>libopencv-dev</depend>
   <depend>yak</depend>
   <depend>yak_ros_msgs</depend>
 
@@ -31,9 +30,10 @@
   <depend>tf2_ros</depend>
   <depend>tf2_eigen</depend>
 
+  <depend>pcl_ros</depend>
   <depend>cv_bridge</depend>
+  <depend>image_transport</depend>
   <depend condition="$BUILD_DEMO == True">gl_depth_sim</depend>
-  <depend condition="$BUILD_DEMO == True">image_transport</depend>
 
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>

--- a/yak_ros/src/demo/sim_depth_image_pub_ros1.cpp
+++ b/yak_ros/src/demo/sim_depth_image_pub_ros1.cpp
@@ -13,13 +13,13 @@
 
 const static std::string DEFAULT_IMAGE_TOPIC = "image";
 
-static Eigen::Affine3d lookat(const Eigen::Vector3d& origin, const Eigen::Vector3d& eye, const Eigen::Vector3d& up)
+static Eigen::Isometry3d lookat(const Eigen::Vector3d& origin, const Eigen::Vector3d& eye, const Eigen::Vector3d& up)
 {
   Eigen::Vector3d z = (eye - origin).normalized();
   Eigen::Vector3d x = z.cross(up).normalized();
   Eigen::Vector3d y = z.cross(x).normalized();
 
-  auto p = Eigen::Affine3d::Identity();
+  auto p = Eigen::Isometry3d::Identity();
   p.translation() = origin;
   p.matrix().col(0).head<3>() = x;
   p.matrix().col(1).head<3>() = y;
@@ -80,7 +80,7 @@ int main(int argc, char** argv)
 
   // Create the simulation
   gl_depth_sim::SimDepthCamera sim (props);
-  sim.add(*mesh_ptr, Eigen::Affine3d::Identity());
+  sim.add(*mesh_ptr, Eigen::Isometry3d::Identity());
 
   // State for FPS monitoring
   long frame_counter = 0;


### PR DESCRIPTION
Depends on [#40 in Yak](https://github.com/ros-industrial/yak/pull/40), since that PR fixes some dependency issues.

- Add CI pipelines for supported combinations of Ubuntu distributions and CUDA versions.
- Fixed a missing `pcl_ros` dependency.
- Fixed trying to install the nonexistent `config` directory.

On Xenial, the version of PCL that is linked through `pcl_ros` uses a different version of VTK than the one PCL is built against in the underlay Docker image, so I had to build the `perception_pcl` package from source in the upstream workspace.