### PR TITLE
Use nice sharp .SVG for support level badge instead of blurry .PNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub Actions status](https://github.com/ros-industrial/yak_ros/workflows/CI/badge.svg?branch=master)](https://github.com/ros-industrial/yak_ros/actions)
 [![GitHub issues open](https://img.shields.io/github/issues/ros-industrial/yak_ros.svg?)](https://github.com/ros-industrial/yak_ros/issues)
 [![license - Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![support level: consortium / vendor](https://img.shields.io/badge/support%20level-consortium%20/%20vendor-brightgreen.png)](http://rosindustrial.org/news/2016/10/7/better-supporting-a-growing-ros-industrial-software-platform)
+[![support level: consortium / vendor](https://img.shields.io/badge/support%20level-consortium%20/%20vendor-brightgreen.svg)](http://rosindustrial.org/news/2016/10/7/better-supporting-a-growing-ros-industrial-software-platform)
 
 Example ROS frontend node for [the Yak TSDF package](https://github.com/ros-industrial/yak).
 


### PR DESCRIPTION
Left: Current

Right: Updated

![image](https://user-images.githubusercontent.com/14431472/92063628-3846dc00-ed61-11ea-82b4-318ff134ce81.png)

The other badges in the README are already `.svg`, so this change makes the support level badge look consistent with the rest.
