### PR TITLE
Reword README and fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 [![license - Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![support level: consortium / vendor](https://img.shields.io/badge/support%20level-consortium%20/%20vendor-brightgreen.svg)](http://rosindustrial.org/news/2016/10/7/better-supporting-a-growing-ros-industrial-software-platform)
 
-Example ROS frontend node for [the Yak TSDF package](https://github.com/ros-industrial/yak).
+A ROS frontend for [the Yak TSDF library](https://github.com/ros-industrial/yak).
 
 ## Demo
 
-This package contains a simulated image generator node and a launch file to provide a self-contained demonstration of TSDF reconstruction from streaming depth images. Currently the demo is only supported for ROS1.
+This package contains a simulated image generator node and a launch file to provide a self-contained demonstration of TSDF reconstruction from streaming depth images.
 
 The demo depends on [the gl_depth_sim package](https://github.com/Jmeyer1292/gl_depth_sim) to provide simulated depth images.
 
-The demo node depends on external packages that aren't required by the core `yak_ros` node, so compilationo of the demo node is skipped by default. To build the demo, pass the `BUILD_DEMO` flag to catkin as `True`:
+The demo node depends on external packages that aren't required by the core `yak_ros` node, so compilation of the demo node is skipped by default. To build the demo, pass the `BUILD_DEMO` flag to catkin as `True`:
 
 ```
 catkin build --cmake-args -DBUILD_DEMO=True


### PR DESCRIPTION
- Delete reference to `yak_ros` as an "example" frontend, since this package is the officially-supported way to interact with Yak within a ROS1 context.
- Delete comment implying ROS2 incompatibility, since that's now supported in `yak_ros2`.
- Fix a spelling error.